### PR TITLE
Added extension validation definition 'is_valid_extension'

### DIFF
--- a/ptn/buttonrolebot/constants.py
+++ b/ptn/buttonrolebot/constants.py
@@ -60,6 +60,8 @@ EMOJI_NOT_DONE = '⭕'
 
 HEX_COLOR_PATTERN = r'^0x[0-9A-Fa-f]{6}$'
 
+VALID_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
 BUTTON_CHOOSE_THUMBNAIL = "https://pilotstradenetwork.com/wp-content/uploads/2023/09/two_buttons_cropped.png"
 BUTTON_SWEAT_THUMBNAIL = "https://pilotstradenetwork.com/wp-content/uploads/2023/09/two_buttons_sweating_guy.png"
 

--- a/ptn/buttonrolebot/modules/Helpers.py
+++ b/ptn/buttonrolebot/modules/Helpers.py
@@ -4,6 +4,11 @@ A module for helper functions called by other modules.
 Depends on: ErrorHandler, Constants
 
 """
+# import os
+import os
+
+#import validators
+import validators
 
 # import discord.py
 import discord
@@ -14,7 +19,7 @@ from discord.ui import View
 from ptn.buttonrolebot.bot import bot, DynamicButton
 
 # import constants
-from ptn.buttonrolebot.constants import bot_guild, channel_botspam
+from ptn.buttonrolebot.constants import bot_guild, channel_botspam, VALID_EXTENSIONS
 
 # import classes
 from ptn.buttonrolebot.classes.RoleButtonData import RoleButtonData
@@ -81,6 +86,11 @@ async def get_guild():
     Return bot guild instance for use in get_member()
     """
     return bot.get_guild(bot_guild())
+
+
+def is_valid_extension(url):
+    _, ext = os.path.splitext(url)
+    return ext.lower() in VALID_EXTENSIONS and validators.url(url)
 
 
 # remove a field from an embed

--- a/ptn/buttonrolebot/ui_elements/EmbedCreator.py
+++ b/ptn/buttonrolebot/ui_elements/EmbedCreator.py
@@ -4,7 +4,7 @@ Define classes for Embed Creator
 Depends on: constants, Embeds, ErrorHandler, Helpers
 
 """
-
+import os
 # import libraries
 import re
 import validators
@@ -94,7 +94,7 @@ class EmbedParamsModal(Modal):
         self.embed_data: EmbedData = embed_data
         self.view = view
 
-    
+
     color = discord.ui.TextInput(
         label='Set the Embed border colour',
         placeholder='Enter a hex colour code in the format 0x00AA00 to use for the embed border.',
@@ -128,7 +128,7 @@ class EmbedParamsModal(Modal):
                 try:
                     color_int = int(self.color.value, 16)  # Convert hex string to integer
                     self.embed_data.embed_color = color_int
-                except ValueError as e: 
+                except ValueError as e:
                     print(e)
                     try:
                         raise GenericError(e)
@@ -153,7 +153,12 @@ class EmbedParamsModal(Modal):
         self.embed_data.embed_author_avatar = self.author_avatar.value if self.author_avatar.value else None
 
         # validate URLs
-        if self.embed_data.embed_thumbnail is not None and not validators.url(self.embed_data.embed_thumbnail):
+        def is_valid_extension(url):
+            VALID_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+            _, ext = os.path.splitext(url)
+            return ext.lower() in VALID_EXTENSIONS and validators.url(url)
+
+        if not is_valid_extension(self.embed_data.embed_thumbnail) and self.embed_data.embed_thumbnail is not None:
             error = f"Thumbnail URL not valid: {self.embed_data.embed_thumbnail}"
             print(error)
             try:
@@ -162,7 +167,7 @@ class EmbedParamsModal(Modal):
                 await on_generic_error(spamchannel, interaction, e)
             return
 
-        if self.embed_data.embed_author_avatar is not None and not validators.url(self.embed_data.embed_author_avatar):
+        if not is_valid_extension(self.embed_data.embed_author_avatar) and self.embed_data.embed_author_avatar is not None:
             error = f"Author Avatar URL not valid: {self.embed_data.embed_author_avatar}"
             print(error)
             try:

--- a/ptn/buttonrolebot/ui_elements/EmbedCreator.py
+++ b/ptn/buttonrolebot/ui_elements/EmbedCreator.py
@@ -18,7 +18,7 @@ from ptn.buttonrolebot.bot import bot
 
 # import local constants
 import ptn.buttonrolebot.constants as constants
-from ptn.buttonrolebot.constants import channel_botspam
+from ptn.buttonrolebot.constants import channel_botspam, VALID_EXTENSIONS
 
 # import local classes
 from ptn.buttonrolebot.classes.EmbedData import EmbedData
@@ -26,7 +26,7 @@ from ptn.buttonrolebot.classes.EmbedData import EmbedData
 # import local modules
 from ptn.buttonrolebot.modules.Embeds import  _generate_embed_from_dict
 from ptn.buttonrolebot.modules.ErrorHandler import GenericError, on_generic_error, CustomError
-from ptn.buttonrolebot.modules.Helpers import _remove_embed_field
+from ptn.buttonrolebot.modules.Helpers import _remove_embed_field, is_valid_extension
 
 spamchannel = bot.get_channel(channel_botspam())
 
@@ -153,11 +153,6 @@ class EmbedParamsModal(Modal):
         self.embed_data.embed_author_avatar = self.author_avatar.value if self.author_avatar.value else None
 
         # validate URLs
-        def is_valid_extension(url):
-            VALID_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
-            _, ext = os.path.splitext(url)
-            return ext.lower() in VALID_EXTENSIONS and validators.url(url)
-
         if not is_valid_extension(self.embed_data.embed_thumbnail) and self.embed_data.embed_thumbnail is not None:
             error = f"Thumbnail URL not valid: {self.embed_data.embed_thumbnail}"
             print(error)


### PR DESCRIPTION
- checks extension for '.jpg', '.jpeg', '.png', '.webp', '.gif'
- check url via validators

Changed thumbnail and avatar error checker to use 'is_valid_extension'

Extension Logic:
```python
        def is_valid_extension(url):
            VALID_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
            _, ext = os.path.splitext(url)
            return ext.lower() in VALID_EXTENSIONS and validators.url(url)
``` 