### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+
+## 1.0.2
+- [#102](https://github.com/PilotsTradeNetwork/ButtonRoleBot/issues/102) Add slash command `/edit_embed` as alternative access to `Edit Bot Embed` function. Takes message ID or URL as an argument.
+
+
 ## 1.0.1
 - [#97](https://github.com/PilotsTradeNetwork/ButtonRoleBot/issues/97) Responds immediately upon button click, then edits response after role management complete
 - Added timeout to role management attempts with appropriate error messages.
+
 
 ## 1.0.0
 - Initial release

--- a/ptn/buttonrolebot/_metadata.py
+++ b/ptn/buttonrolebot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/ptn/buttonrolebot/ui_elements/EmbedCreator.py
+++ b/ptn/buttonrolebot/ui_elements/EmbedCreator.py
@@ -6,6 +6,7 @@ Depends on: constants, Embeds, ErrorHandler, Helpers
 """
 # import libraries
 import re
+import traceback
 
 # import discord.py
 import discord
@@ -25,7 +26,39 @@ from ptn.buttonrolebot.classes.FieldData import FieldData
 # import local modules
 from ptn.buttonrolebot.modules.Embeds import  _generate_embed_from_dict
 from ptn.buttonrolebot.modules.ErrorHandler import GenericError, on_generic_error, CustomError
-from ptn.buttonrolebot.modules.Helpers import _remove_embed_field, is_valid_extension
+from ptn.buttonrolebot.modules.Helpers import _remove_embed_field, is_valid_extension, _get_embed_from_message
+
+
+# function shared by Edit Bot Embed and /edit_embed to edit an embed sent by the bot
+async def _edit_bot_embed(interaction: discord.Interaction, message: discord.Message):
+    print("Called _edit_bot_embed")
+    spamchannel = bot.get_channel(channel_botspam())
+    try:
+        instruction_embed = discord.Embed(
+            title='⚙ EDITING EMBED',
+            color=constants.EMBED_COLOUR_QU
+        )
+
+        # get the embed from the message
+        embed_data = _get_embed_from_message(message)
+
+        preview_embed = _generate_embed_from_dict(embed_data)
+
+        view = EmbedGenButtons(instruction_embed, embed_data, message, 'edit')
+
+        embeds = [instruction_embed, preview_embed]
+
+        await interaction.response.send_message(embeds=embeds, view=view, ephemeral=True)
+
+    except Exception as e:
+        print(e)
+        traceback.print_exc()
+        try:
+            raise GenericError(e)
+        except Exception as e:
+            await on_generic_error(spamchannel, interaction, e)
+        return
+
 
 """
 EMBED CREATOR

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'DateTime==4.3',
         'discord==1.0.1',
-        'discord.py>=2.3.0',
+        'discord.py>=2.3.0', # requires d.py > 2.4.0 which is pre-release. Use pip install -U git+https://github.com/Rapptz/discord.py
         'emoji>=2.8.0',
         'python-dotenv==0.15.0',
         'python-dateutil>=2.8.1',


### PR DESCRIPTION
- [#102](https://github.com/PilotsTradeNetwork/ButtonRoleBot/issues/102) Add slash command `/edit_embed` as alternative access to `Edit Bot Embed` function. Takes message ID or URL as an argument.