### PR TITLE
Add selectable loglevel to ButtonRoleBot

### DIFF
--- a/ptn/buttonrolebot/application.py
+++ b/ptn/buttonrolebot/application.py
@@ -14,7 +14,8 @@ from ptn.buttonrolebot.botcommands.AdminCommands import AdminCommands
 from ptn.buttonrolebot.botcommands.ButtonRoleCommands import ButtonRoleCommands
 
 # import bot object, token, production status
-from ptn.buttonrolebot.constants import TOKEN, _production, DATA_DIR
+from ptn.buttonrolebot.constants import TOKEN, _production, DATA_DIR, log_handler, LOG_LEVEL
+from discord.utils import setup_logging
 from ptn.buttonrolebot.bot import bot
 
 print(f"Data dir is {DATA_DIR} from {os.path.join(os.getcwd(), 'ptn', 'buttonrolebot', DATA_DIR, '.env')}")
@@ -31,6 +32,7 @@ async def buttonrolebot():
         await bot.add_cog(AdminCommands(bot))
         await bot.add_cog(ButtonRoleCommands(bot))
         await bot.add_cog(PrometheusCog(bot))
+        setup_logging(handler=log_handler, level=LOG_LEVEL)
         await bot.start(TOKEN)
 
 

--- a/ptn/buttonrolebot/constants.py
+++ b/ptn/buttonrolebot/constants.py
@@ -8,6 +8,8 @@ Depends on: nothing
 import ast
 import os
 import discord
+import sys
+import logging
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -199,3 +201,23 @@ Regular emojis can be used by emoji keyboard or Discord shortcut, e.g. :wave: `:
 
 any_elevated_role = [role_council(), role_mod(), role_cmentor(), role_somm(), role_foperative(), role_pathfinder()]
 
+# define the logger for discord client and asyncpraw.
+# TODO: use PTNLogger and extend to all MAB Logging
+log_handler = logging.StreamHandler(sys.stdout)
+
+loglevel_input = os.getenv('ROLE_BOT_LOG_LEVEL', 'INFO')
+match loglevel_input:
+    case 'CRITICAL':
+        LOG_LEVEL = logging.CRITICAL
+
+    case 'ERROR':
+        LOG_LEVEL = logging.ERROR
+
+    case 'INFO':
+        LOG_LEVEL = logging.INFO
+
+    case 'DEBUG':
+        LOG_LEVEL = logging.DEBUG
+
+    case _:
+        LOG_LEVEL = logging.INFO


### PR DESCRIPTION
fixes #123

requires new environment variable ROLE_BOT_LOG_LEVEL, which may take on values in {CRITICAL, ERROR, INFO, DEBUG}. All other values are defaulted to INFO