### PR TITLE
Disable member caching, prune intents

### DIFF
--- a/ptn/buttonrolebot/_metadata.py
+++ b/ptn/buttonrolebot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '1.0.7'
+__version__ = '1.1.0'

--- a/ptn/buttonrolebot/bot.py
+++ b/ptn/buttonrolebot/bot.py
@@ -24,6 +24,7 @@ from ptn.buttonrolebot.constants import channel_botdev, channel_botspam, EMBED_C
 
 # import modules
 from ptn.buttonrolebot.modules.ErrorHandler import CustomError, on_generic_error
+from ptn.buttonrolebot.utils import get_member
 
 
 """
@@ -80,7 +81,7 @@ class DynamicButton(discord.ui.DynamicItem[discord.ui.Button], template = r'butt
                 role = discord.utils.get(interaction.guild.roles, id=self.role_id)
 
                 # check if we have permissions for this role
-                bot_member: discord.Member = interaction.guild.get_member(bot.user.id)
+                bot_member: discord.Member = await get_member(bot, bot.user.id)
                 if bot_member.top_role <= role or role.managed:
                     print(f"⚠ We don't have permission for {role}")
                     try:
@@ -211,10 +212,13 @@ Bot object
 # define bot object
 class ButtonRoleBot(commands.Bot):
     def __init__(self):
-        intents = discord.Intents.all()
+        intents = discord.Intents.none()
         intents.message_content = True
+        intents.members = True
+        intents.messages = True
+        intents.guilds = True
 
-        super().__init__(command_prefix=commands.when_mentioned_or('🎢'), intents=intents)
+        super().__init__(command_prefix=commands.when_mentioned_or('🎢'), intents=intents, chunk_guilds_at_startup=False)
 
     async def setup_hook(self) -> None:
 

--- a/ptn/buttonrolebot/modules/Helpers.py
+++ b/ptn/buttonrolebot/modules/Helpers.py
@@ -15,6 +15,7 @@ import validators
 # import discord.py
 import discord
 from discord import app_commands
+from ptn.buttonrolebot.utils import get_member
 
 # import bot
 from ptn.buttonrolebot.bot import bot, DynamicButton
@@ -83,7 +84,7 @@ def check_roles(permitted_role_ids):
 
 def check_channel_permissions(): # does this work? I have no idea. Discord seems to disable interactions in channels you don't have send permissions in, even if explicitly enabled. 🤷‍♀️
     async def checkuserperms(interaction: discord.Interaction):
-        member: discord.Member = interaction.guild.get_member(interaction.user.id)
+        member: discord.Member = await get_member(bot, interaction.user.id)
         user_permissions: discord.Permissions = interaction.channel.permissions_for(member)
         permission = user_permissions.send_messages
         if not permission:
@@ -100,7 +101,7 @@ async def button_role_checks(interaction: discord.Interaction, role: discord.Rol
     print(f"Called button_role_checks for {role}")
     try:
         # check if we have permission to manage this role
-        bot_member: discord.Member = interaction.guild.get_member(bot.user.id)
+        bot_member: discord.Member = await get_member(bot, bot.user.id)
         if bot_member.top_role <= role or role.managed:
             print("We don't have permission for this role")
             try:

--- a/ptn/buttonrolebot/utils.py
+++ b/ptn/buttonrolebot/utils.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from discord import Guild, Member, NotFound, User
+from discord.ext.commands import Bot
+
+from ptn.buttonrolebot.constants import bot_guild
+
+
+async def get_user(bot: Bot, user_id: int) -> Optional[User]:
+    """Fetch a user from the cache or API."""
+    try:
+        return bot.get_user(user_id) or await bot.fetch_user(user_id)
+    except NotFound:
+        return None
+
+
+async def get_guild(bot: Bot, guild: int = bot_guild()) -> Optional[Guild]:
+    """Return bot guild instance for use in get_member()"""
+    return bot.get_guild(guild) or await bot.fetch_guild(guild)
+
+
+async def get_member(bot: Bot, member_id: int) -> Optional[Member]:
+    """Fetch a member from the cache or API."""
+    guild = await get_guild(bot)
+    try:
+        return guild.get_member(member_id) or await guild.fetch_member(member_id)
+    except NotFound:
+        return None


### PR DESCRIPTION
Fixes #127

set chunk_guilds_at_startup to False, requires get/fetch utility import from MAB.

Intents pruned to minimum required with current functionality